### PR TITLE
404 back to homepage

### DIFF
--- a/src/components/buttons/ExpandedLink.astro
+++ b/src/components/buttons/ExpandedLink.astro
@@ -1,13 +1,19 @@
 ---
 interface Props {
+    class?: string;
     href: string;
+    targetSelf?: boolean;
 };
 const props: Props = Astro.props;
 ---
 
 <a
-    class='bg-high duration-500 ease-in-out flex gap-2 items-center p-4 rounded-2xl text-xl text-txt-high hover:text-accent transition-colors uppercase'
+    class:list={[
+        'bg-high duration-500 ease-in-out flex gap-2 items-center p-4 rounded-2xl text-xl text-txt-high hover:text-accent transition-colors uppercase',
+        props.class
+    ]}
     href={props.href}
-    target='_blank'>
+    target={props.targetSelf === false ? '_self' : '_blank'}
+>
     <slot />
 </a>

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,5 +1,6 @@
 ---
 import CommonHead from '@components/CommonHead.astro';
+import ExpandedLink from '@components/buttons/ExpandedLink.astro';
 import { SdIcon } from '@components/icons/icons';
 
 const title = 'Not Found';
@@ -15,7 +16,10 @@ const route = Astro.url.pathname;
                 <span class='text-accent'>404</span>
                 : Not found
             </h1>
-            <pre class='text-txt-medium mt-4'>Path: {route}</pre>
+            <pre class='text-txt-medium mt-4 mb-12'>Path: {route}</pre>
+            <ExpandedLink class='font-bold' href='/' targetSelf={false}>
+                Back to homepage
+            </ExpandedLink>
         </main>
     </body>
 </html>

--- a/src/pages/about-this-page.astro
+++ b/src/pages/about-this-page.astro
@@ -23,8 +23,11 @@ import ExpandedLink from '@components/buttons/ExpandedLink.astro';
             ))}
         </div>
         <div class='w-fit'>
-            <ExpandedLink href='https://github.com/sponsors/Stratis-Dermanoutsos'>
-                <span class='font-bold text-accent'>Sponsor me on GitHub</span>
+            <ExpandedLink
+                class='font-bold text-accent'
+                href='https://github.com/sponsors/Stratis-Dermanoutsos'
+            >
+                Sponsor me on GitHub
             </ExpandedLink>
         </div>
     </div>


### PR DESCRIPTION
New Expanded link props:

- `targetSelf`: Determines if the href should open in the same browser tab.
- `class`: Fill additional classes to the link for customisation.